### PR TITLE
#47 cutting participant names when too long

### DIFF
--- a/lib/src/view/meeting_info/meeting_info_view.dart
+++ b/lib/src/view/meeting_info/meeting_info_view.dart
@@ -300,7 +300,13 @@ class _MeetingInfoViewState extends State<MeetingInfoView> {
                   Icons.desktop_windows,
                   size: 20.0,
                 )),
-          Text(user.name),
+          Expanded(
+            child: Text(
+              user.name,
+              overflow: TextOverflow.fade,
+              softWrap: false,
+            ),
+          ),
           if (isCurrentUser)
             Text(" (" +
                 AppLocalizations.of(context).get("meeting-info.you") +


### PR DESCRIPTION
Closes #47 

Resulting fade effect:
![grafik](https://user-images.githubusercontent.com/14014633/99148695-7a599b80-2689-11eb-86b5-dc3c278656cb.png)
