### PR TITLE
Bump version of intl 0.16.1 > 0.17.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,7 @@ dependencies:
   html: ^0.14.0+4
   day_night_switcher: ^0.1.1+1
   provider: ^4.3.3
-  intl: ^0.16.1
+  intl: ^0.17.0
   sprintf: ^5.0.0
   flutter_svg: ^0.19.1
   sip_ua: #^0.3.5


### PR DESCRIPTION
Bump version of intl 0.16.1 > 0.17.0

While trying to build and run the app the issue of version for this package came and recommended version was 0.17.0.